### PR TITLE
fix(parsers): Fix a typo

### DIFF
--- a/ts-fold-parsers.el
+++ b/ts-fold-parsers.el
@@ -115,7 +115,7 @@
     (comment
      . (lambda (node offset)
          (ts-fold-range-line-comment node offset "#")))
-    (do_block .ts-fold-range-elixir)))
+    (do_block . ts-fold-range-elixir)))
 
 (defun ts-fold-parsers-go ()
   "Rule sets for Go."


### PR DESCRIPTION
Fix this error: `ts-fold--get-fold-range: Symbol’s function definition is void: \.ts-fold-range-elixir`.