### PR TITLE
OCaml parser and first functions added

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ These languages are in development:
 * Agda
 * Elm
 * Emacs Lisp
+* OCaml
 * XML (upstream)
 
 ## ⚖️ Indicators Mode

--- a/ts-fold-parsers.el
+++ b/ts-fold-parsers.el
@@ -45,6 +45,7 @@
 (declare-function ts-fold-range-c-preproc-elif "ts-fold.el")
 (declare-function ts-fold-range-c-preproc-else "ts-fold.el")
 (declare-function ts-fold-range-html "ts-fold.el")
+(declare-function ts-fold-range-ocaml "ts-fold.el")
 (declare-function ts-fold-range-python "ts-fold.el")
 (declare-function ts-fold-range-ruby "ts-fold.el")
 (declare-function ts-fold-range-rust-macro "ts-fold.el")
@@ -170,6 +171,13 @@
          (if (string-prefix-p "#" (tsc-node-text node))
              (ts-fold-range-line-comment node offset "#")
            (ts-fold-range-c-like-comment node offset))))))
+
+(defun ts-fold-parsers-ocaml ()
+  "Rule sets for OCaml."
+  '((comment             . ts-fold-range-ocaml-comment)
+    (module_definition   . ts-fold-range-ocaml-module-definition)
+    (type_definition     . ts-fold-range-ocaml-type-definition)
+    (value_definition    . ts-fold-range-ocaml-value-definition)))
 
 (defun ts-fold-parsers-python ()
   "Rule sets for Python."

--- a/ts-fold.el
+++ b/ts-fold.el
@@ -90,6 +90,7 @@ The alist is in form of (major-mode . (foldable-node-type)).")
     (sh-mode         . ,(ts-fold-parsers-bash))
     (scala-mode      . ,(ts-fold-parsers-scala))
     (swift-mode      . ,(ts-fold-parsers-swift))
+    (tuareg-mode     . ,(ts-fold-parsers-ocaml))
     (typescript-mode . ,(ts-fold-parsers-typescript)))
   "An alist of (major-mode . (foldable-node-type . function)).
 
@@ -365,6 +366,10 @@ in backward direction."
       (setq iter-node (ts-fold--next-prev-node iter-node next)))
     last-node))
 
+(defun ts-fold--one-liner-node (node)
+  "Helper function to check if NODE is on one line only."
+  (= (car (aref (tsc-node-range node) 2)) (car (aref (tsc-node-range node) 3))))
+
 (defun ts-fold-range-seq (node offset)
   "Return the fold range in sequence starting from NODE.
 
@@ -445,6 +450,71 @@ more information."
          (end-node (tsc-get-nth-child node (1- (tsc-count-children node))))
          (end (tsc-node-start-position end-node)))
     (ts-fold--cons-add (cons beg end) offset)))
+
+;;+ OCaml
+
+(defun ts-fold-range-ocaml-comment (node offset)
+  "Define fold range for `comment'.
+
+For arguments NODE and OFFSET, see function `ts-fold-range-seq' for
+more information."
+  (unless (ts-fold--one-liner-node node)
+    (when-let*
+        ((text  (tsc-node-text node))
+         (beg   (if (string-prefix-p "(* " text)
+                    (+ 2 (tsc-node-start-position node))
+                  (+ 3 (tsc-node-start-position node))))
+         (end   (- (tsc-node-end-position node) 2)))
+      (ts-fold--cons-add (cons beg end) offset))))
+
+(defun ts-fold-range-ocaml-module-definition (node offset)
+  "Define fold range for `module_definition'.
+
+For arguments NODE and OFFSET, see function `ts-fold-range-seq' for
+more information."
+  (unless (ts-fold--one-liner-node node)
+    (when-let*
+        ((module-binding (tsc-get-nth-named-child node 0))
+         (body           (tsc-get-child-by-field module-binding :body))
+         ;; body is struct ... end
+         (beg            (+ 6 (tsc-node-start-position body)))
+         (end            (- (tsc-node-end-position node) 3)))
+      (ts-fold--cons-add (cons beg end) offset))))
+
+(defun ts-fold-range-ocaml-type-definition (node offset)
+  "Define fold range for `type_definition'.
+
+For arguments NODE and OFFSET, see function `ts-fold-range-seq' for
+more information."
+  (unless (ts-fold--one-liner-node node)
+    (when-let*
+        ((type-definition (tsc-get-nth-named-child node 0))
+         (body            (tsc-get-child-by-field type-definition :body))
+         (text            (tsc-node-text (tsc-get-nth-child body 0)))
+         (beg
+          (if (string-equal "{" text)
+              (1+ (tsc-node-start-position body))
+            (tsc-node-end-position (tsc-get-prev-sibling body))))
+         (end
+          (if (string-equal "{" text)
+              (1- (tsc-node-end-position node))
+            (tsc-node-end-position node))))
+      (ts-fold--cons-add (cons beg end) offset))))
+
+(defun ts-fold-range-ocaml-value-definition (node offset)
+  "Define fold range for `value_definition'.
+
+For arguments NODE and OFFSET, see function `ts-fold-range-seq' for
+more information."
+  (unless (ts-fold--one-liner-node node)
+    (when-let*
+        ((let-binding  (tsc-get-nth-named-child node 0))
+         (body         (tsc-get-child-by-field let-binding :body))
+         (beg          (tsc-node-end-position (tsc-get-prev-sibling body)))
+         (end          (tsc-node-end-position node)))
+      (ts-fold--cons-add (cons beg end) offset))))
+
+;;- OCaml
 
 (defun ts-fold-range-python (node offset)
   "Define fold range for `function_definition' and `class_definition'.


### PR DESCRIPTION
This update allows to fold comments, value, type and module definitions if they're not on one line only

I'm not sure about the one line rule but it seems strange to fold a value that fits on one line

resolves #18 