### PR TITLE
[WiP] New idea: fold all selected types

### DIFF
--- a/ts-fold.el
+++ b/ts-fold.el
@@ -301,6 +301,21 @@ If the current node is not folded or not foldable, do nothing."
                    (mapc #'ts-fold-close)))))
 
 ;;;###autoload
+(defun ts-fold-close-all-selected (type)
+  "Fold all foldable syntax nodes corresponding to TYPE in the buffer."
+  (interactive "SType: ")
+  (ts-fold--ensure-ts
+    (let* ((node (tsc-root-node tree-sitter-tree))
+           (patterns (vector (list type) '@name))
+           (query (tsc-make-query tree-sitter-language patterns))
+           (nodes-to-fold (tsc-query-captures query node #'ignore))
+           )
+      (thread-last nodes-to-fold
+                   (mapcar #'cdr)
+                   (mapc #'ts-fold-close))
+      )))
+
+;;;###autoload
 (defun ts-fold-open-all ()
   "Unfold all syntax nodes in the buffer."
   (interactive)


### PR DESCRIPTION
Allow the user to chose exactly the type of nodes they want to fold when folding all.

The current implementation expects the user to know the values in the tree-sitter syntax tree which is not really user-friendly.

My idea would be to put this function behind an imenu or something like this to show exactly what are the possible syntax values that can be folded